### PR TITLE
Add One Piece character discord bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,42 @@
-# DiscordBotNote
+# One Piece Character Discord Bots
 
+This repository contains Discord bots that provide information about characters from the popular anime and manga series One Piece.
 
-Damn I have to throw a once piece buffet after the reset.
+## Setup and Run
 
-Professor: comformal  map grabs the infinity ***hawking" points and send it to "frontal lobe"
+To set up and run the bots, follow these steps:
 
-me: reckoning. Buzz light yearrrrrrrrrrrrrrrrrrrrrrr to the infinity and beyond!
+1. Clone the repository:
+   ```
+   git clone https://github.com/ewdlop/DiscordBotNote.git
+   cd DiscordBotNote
+   ```
 
-https://en.wikipedia.org/wiki/K%C3%A4hler_manifold
+2. Install the required dependencies:
+   ```
+   pip install -r requirements.txt
+   ```
+
+3. Create a new file named `.env` in the root directory of the repository and add your Discord bot token:
+   ```
+   DISCORD_TOKEN=your_discord_bot_token
+   ```
+
+4. Run the bot:
+   ```
+   python bot.py
+   ```
+
+## Available Commands
+
+The following commands are available for the One Piece character Discord bots:
+
+- `!luffy`: Provides information about Monkey D. Luffy.
+- `!zoro`: Provides information about Roronoa Zoro.
+- `!nami`: Provides information about Nami.
+- `!sanji`: Provides information about Sanji.
+- `!chopper`: Provides information about Tony Tony Chopper.
+- `!robin`: Provides information about Nico Robin.
+- `!franky`: Provides information about Franky.
+- `!brook`: Provides information about Brook.
+- `!jinbe`: Provides information about Jinbe.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,60 @@
+import os
+import discord
+from discord.ext import commands
+from dotenv import load_dotenv
+
+load_dotenv()
+TOKEN = os.getenv('DISCORD_TOKEN')
+
+bot = commands.Bot(command_prefix='!')
+
+@bot.event
+async def on_ready():
+    print(f'{bot.user.name} has connected to Discord!')
+
+@bot.command(name='luffy')
+async def luffy(ctx):
+    response = "Monkey D. Luffy is the captain of the Straw Hat Pirates."
+    await ctx.send(response)
+
+@bot.command(name='zoro')
+async def zoro(ctx):
+    response = "Roronoa Zoro is the swordsman of the Straw Hat Pirates."
+    await ctx.send(response)
+
+@bot.command(name='nami')
+async def nami(ctx):
+    response = "Nami is the navigator of the Straw Hat Pirates."
+    await ctx.send(response)
+
+@bot.command(name='sanji')
+async def sanji(ctx):
+    response = "Sanji is the cook of the Straw Hat Pirates."
+    await ctx.send(response)
+
+@bot.command(name='chopper')
+async def chopper(ctx):
+    response = "Tony Tony Chopper is the doctor of the Straw Hat Pirates."
+    await ctx.send(response)
+
+@bot.command(name='robin')
+async def robin(ctx):
+    response = "Nico Robin is the archaeologist of the Straw Hat Pirates."
+    await ctx.send(response)
+
+@bot.command(name='franky')
+async def franky(ctx):
+    response = "Franky is the shipwright of the Thousand Sunny."
+    await ctx.send(response)
+
+@bot.command(name='brook')
+async def brook(ctx):
+    response = "Brook is the musician of the Straw Hat Pirates."
+    await ctx.send(response)
+
+@bot.command(name='jinbe')
+async def jinbe(ctx):
+    response = "Jinbe is the helmsman of the Straw Hat Pirates."
+    await ctx.send(response)
+
+bot.run(TOKEN)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+discord.py
+python-dotenv


### PR DESCRIPTION
Add One Piece character Discord bots and update README.md

* **README.md**
  - Update the content to describe the One Piece character Discord bots.
  - Add instructions on how to set up and run the bots.
  - Include a list of available commands and their descriptions.

* **bot.py**
  - Create a new file to implement the main bot logic.
  - Import necessary libraries and set up the bot client.
  - Add event handlers for bot commands related to One Piece characters.
  - Implement command functions to provide information about One Piece characters.

* **requirements.txt**
  - List the required dependencies for the bot, including `discord.py` and `python-dotenv`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ewdlop/DiscordBotNote/pull/1?shareId=511ab8c4-b470-4633-80ec-cee7475a40b6).